### PR TITLE
Add options trading template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+.venv
+.DS_Store
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# options-trader
+# Options Trader Template
+
+This repository provides a minimal starting point for building a machine
+learning model that suggests future options trades based on historical data.
+
+## Getting Started
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Ensure the source directory is on your Python path and run the example
+   training script:
+
+   ```bash
+   export PYTHONPATH=src
+   python -m options_trader.train
+   ```
+
+The script downloads a single option chain using `yfinance`, prepares a simple
+feature matrix and fits a `RandomForestRegressor` to predict option prices.  The
+pipeline is intentionally basic and serves as a foundation for more advanced
+research into profitable options strategies.
+
+## Project Structure
+
+- `src/options_trader/` – core package containing data utilities, model
+  definitions and training script.
+- `tests/` – unit tests for the package.
+- `requirements.txt` – Python dependencies.
+
+Feel free to expand on this template by adding data storage, more sophisticated
+models and evaluation metrics.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+yfinance
+scikit-learn

--- a/src/options_trader/__init__.py
+++ b/src/options_trader/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for the options trader template."""

--- a/src/options_trader/data_loader.py
+++ b/src/options_trader/data_loader.py
@@ -1,0 +1,53 @@
+"""Utilities for downloading and preparing options data."""
+
+from __future__ import annotations
+
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_option_chain(ticker: str, expiration: str) -> pd.DataFrame:
+    """Fetch the option chain for ``ticker`` and ``expiration``.
+
+    Parameters
+    ----------
+    ticker:
+        Ticker symbol such as ``"AAPL"``.
+    expiration:
+        Expiration date in ``YYYY-MM-DD`` format.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Combined calls and puts for the requested expiration.
+    """
+    stock = yf.Ticker(ticker)
+    chain = stock.option_chain(expiration)
+    calls = chain.calls.assign(option_type="call")
+    puts = chain.puts.assign(option_type="put")
+    data = pd.concat([calls, puts], ignore_index=True)
+    return data
+
+
+def prepare_features(option_chain: pd.DataFrame) -> pd.DataFrame:
+    """Generate a simple feature matrix from an option chain.
+
+    The function keeps a subset of numeric columns and adds a binary
+    ``is_call`` flag which can be used as a target variable or feature.
+    Missing values are filled with zeros.
+    """
+    features = option_chain[
+        [
+            "strike",
+            "lastPrice",
+            "bid",
+            "ask",
+            "change",
+            "volume",
+            "openInterest",
+            "impliedVolatility",
+            "option_type",
+        ]
+    ].copy()
+    features["is_call"] = (features.pop("option_type") == "call").astype(int)
+    return features.fillna(0)

--- a/src/options_trader/model.py
+++ b/src/options_trader/model.py
@@ -1,0 +1,8 @@
+"""Model definitions used by the options trader template."""
+
+from sklearn.ensemble import RandomForestRegressor
+
+
+def build_model() -> RandomForestRegressor:
+    """Return a simple random forest regressor with sensible defaults."""
+    return RandomForestRegressor(n_estimators=100, random_state=42)

--- a/src/options_trader/train.py
+++ b/src/options_trader/train.py
@@ -1,0 +1,43 @@
+"""Example training script.
+
+This module demonstrates how the pieces of the template fit together.  It
+fetches an option chain using :mod:`yfinance`, prepares a feature matrix and
+trains a simple model.
+"""
+
+from __future__ import annotations
+
+import yfinance as yf
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+from .data_loader import fetch_option_chain, prepare_features
+from .model import build_model
+
+
+def main(ticker: str = "AAPL") -> None:
+    """Run a minimal training experiment for ``ticker``.
+
+    The function fetches the nearest expiration option chain for ``ticker`` and
+    trains a :class:`~sklearn.ensemble.RandomForestRegressor` to predict the
+    ``lastPrice`` of options contracts.  The reported metric is the root mean
+    squared error on a hold-out test set.
+    """
+    stock = yf.Ticker(ticker)
+    expiration = stock.options[0]
+    chain = fetch_option_chain(ticker, expiration)
+    features = prepare_features(chain)
+    target = chain["lastPrice"]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        features, target, test_size=0.2, random_state=42
+    )
+    model = build_model()
+    model.fit(X_train, y_train)
+    predictions = model.predict(X_test)
+    rmse = mean_squared_error(y_test, predictions, squared=False)
+    print(f"Trained on {ticker} options expiring {expiration}. RMSE: {rmse:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from options_trader.data_loader import prepare_features
+
+
+def test_prepare_features_generates_is_call_flag():
+    sample = pd.DataFrame(
+        {
+            "strike": [100],
+            "lastPrice": [1.2],
+            "bid": [1.1],
+            "ask": [1.3],
+            "change": [0.1],
+            "volume": [100],
+            "openInterest": [200],
+            "impliedVolatility": [0.2],
+            "option_type": ["call"],
+        }
+    )
+    features = prepare_features(sample)
+    assert "is_call" in features.columns
+    assert features["is_call"].iloc[0] == 1


### PR DESCRIPTION
## Summary
- scaffold basic options trading research project
- provide data loader, baseline model, and training script
- document setup and add simple unit test

## Testing
- `pytest`
- `python -m py_compile $(find . -name '*.py' -not -path './.venv/*')`


------
https://chatgpt.com/codex/tasks/task_e_689fb6b3c570832fbe70fbbae5051e1c