### PR TITLE
Add Tesla stock price training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,28 @@ learning model that suggests future options trades based on historical data.
    pip install -r requirements.txt
    ```
 
-2. Ensure the source directory is on your Python path and run the example
-   training script:
+2. Ensure the source directory is on your Python path and run one of the
+   example training scripts:
 
    ```bash
    export PYTHONPATH=src
+   # Option price example
    python -m options_trader.train
+
+   # Tesla stock price example via QuantConnect
+   export QC_USER_ID=<your-user-id>
+   export QC_API_TOKEN=<your-api-token>
+   python -m options_trader.tsla_example
    ```
 
-The script downloads a single option chain using `yfinance`, prepares a simple
-feature matrix and fits a `RandomForestRegressor` to predict option prices.  The
-pipeline is intentionally basic and serves as a foundation for more advanced
-research into profitable options strategies.
+`options_trader.train` downloads a single option chain using `yfinance`,
+prepares a simple feature matrix and fits a `RandomForestRegressor` to predict
+option prices.  `options_trader.tsla_example` uses QuantConnect's Data API to
+download daily Tesla prices for 2025, trains a model to predict the next day's
+close and reports the RMSE. These pipelines are intentionally basic and serve as
+foundations for more advanced research into profitable strategies. QuantConnect
+credentials are required for the stock example and may incur data costs; see the
+QuantConnect terms of use for details.
 
 ## Project Structure
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 yfinance
 scikit-learn
+requests

--- a/src/options_trader/tsla_example.py
+++ b/src/options_trader/tsla_example.py
@@ -1,0 +1,96 @@
+"""Train a simple model on Tesla stock prices from QuantConnect."""
+
+from __future__ import annotations
+
+import io
+import os
+from typing import Literal
+
+import pandas as pd
+import requests
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+
+API_URL = "https://www.quantconnect.com/api/v2/data/read"
+
+
+def load_data(
+    ticker: str = "TSLA",
+    start: str = "2025-01-01",
+    end: str = "2025-12-31",
+    *,
+    user_id: str | None = None,
+    api_token: str | None = None,
+    market: Literal["USA"] = "USA",
+    resolution: Literal["Daily"] = "Daily",
+) -> pd.DataFrame:
+    """Download daily prices from QuantConnect and add next-day close.
+
+    Parameters are passed directly to QuantConnect's Data API. `user_id` and
+    `api_token` default to the ``QC_USER_ID`` and ``QC_API_TOKEN`` environment
+    variables. Visit https://www.quantconnect.com/docs/v2/our-platform/lean-cli/api
+    to obtain your credentials.
+    """
+
+    user_id = user_id or os.getenv("QC_USER_ID")
+    api_token = api_token or os.getenv("QC_API_TOKEN")
+    if not user_id or not api_token:
+        raise RuntimeError("Set QC_USER_ID and QC_API_TOKEN environment variables")
+
+    params = {
+        "type": "Equity",
+        "ticker": ticker,
+        "market": market,
+        "resolution": resolution,
+        "start": start.replace("-", ""),
+        "end": end.replace("-", ""),
+        "dataNormalizationMode": "Adjusted",
+    }
+    resp = requests.get(API_URL, params=params, auth=(user_id, api_token), timeout=30)
+    resp.raise_for_status()
+
+    df = pd.read_csv(io.StringIO(resp.text))
+    df["time"] = pd.to_datetime(df["time"], errors="coerce")
+    df = df.dropna(subset=["time"]).sort_values("time")
+    df = df.rename(
+        columns={
+            "time": "date",
+            "open": "open",
+            "high": "high",
+            "low": "low",
+            "close": "close",
+            "volume": "volume",
+        }
+    )
+    df["close_next"] = df["close"].shift(-1)
+    return df.dropna()
+
+
+def train_model(data: pd.DataFrame) -> float:
+    """Train RandomForestRegressor to predict next-day close."""
+    features = ["open", "high", "low", "close", "volume"]
+    X = data[features]
+    y = data["close_next"]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+
+    model = RandomForestRegressor(n_estimators=200, random_state=42)
+    model.fit(X_train, y_train)
+    preds = model.predict(X_test)
+    mse = mean_squared_error(y_test, preds)
+    rmse = mse ** 0.5
+    print(f"RMSE: {rmse:.2f}")
+    return rmse
+
+
+def main() -> None:
+    """Execute a training run and report RMSE."""
+    data = load_data()
+    train_model(data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch `tsla_example` to download 2025 daily prices from QuantConnect's Data API
- document required QuantConnect credentials in README
- include `requests` dependency for QuantConnect API calls

## Testing
- `PYTHONPATH=src QC_USER_ID=1 QC_API_TOKEN=abc python -m options_trader.tsla_example` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fb869f2a4832f995bfa9f3bf9e3f1